### PR TITLE
Zip 27

### DIFF
--- a/Projects/Features/QuestionFeature/Sources/Answer/AnswerTableHeaderView.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/AnswerTableHeaderView.swift
@@ -14,7 +14,7 @@ final class AnswerTableHeaderView: UIView {
         let label = UILabel()
         label.font = ZipthingFont.title6
         label.text = "답변"
-        label.textColor = .black
+        label.textColor = DesignSystemAsset.black.color
         return label
     }()
     
@@ -32,8 +32,8 @@ final class AnswerTableHeaderView: UIView {
         configuration.title = "최신순"
         configuration.attributedTitle?.font = ZipthingFont.subTitle4
         let button = UIButton(configuration: configuration)
-        button.backgroundColor = .black
-        button.tintColor = .white
+        button.backgroundColor = DesignSystemAsset.black.color
+        button.tintColor = DesignSystemAsset.white.color
         button.layer.cornerRadius = 4
         return button
     }()
@@ -43,8 +43,8 @@ final class AnswerTableHeaderView: UIView {
         configuration.title = "시간순"
         configuration.attributedTitle?.font = ZipthingFont.subTitle4
         let button = UIButton(configuration: configuration)
-        button.backgroundColor = .gray
-        button.tintColor = .white
+        button.backgroundColor = DesignSystemAsset.wgray07.color
+        button.tintColor = DesignSystemAsset.white.color
         button.layer.cornerRadius = 4
         return button
     }()

--- a/Projects/Features/QuestionFeature/Sources/Answer/AnswerTableHeaderView.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/AnswerTableHeaderView.swift
@@ -1,0 +1,93 @@
+//
+//  AnswerTableHeaderView.swift
+//  QuestionFeature
+//
+//  Created by playhong on 2/18/24.
+//  Copyright © 2024 Zipthing. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+
+final class AnswerTableHeaderView: UIView {
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = ZipthingFont.title6
+        label.text = "답변"
+        label.textColor = .black
+        return label
+    }()
+    
+    private lazy var buttonStackView: UIStackView = {
+        let sv = UIStackView(arrangedSubviews: [latestOrderButton, timeOrderButton])
+        sv.axis = .horizontal
+        sv.alignment = .fill
+        sv.distribution = .fill
+        sv.spacing = 8
+        return sv
+    }()
+    
+    private let latestOrderButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = "최신순"
+        configuration.attributedTitle?.font = ZipthingFont.subTitle4
+        let button = UIButton(configuration: configuration)
+        button.backgroundColor = .black
+        button.tintColor = .white
+        button.layer.cornerRadius = 4
+        return button
+    }()
+    
+    private let timeOrderButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = "시간순"
+        configuration.attributedTitle?.font = ZipthingFont.subTitle4
+        let button = UIButton(configuration: configuration)
+        button.backgroundColor = .gray
+        button.tintColor = .white
+        button.layer.cornerRadius = 4
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        self.backgroundColor = .clear
+    }
+    
+    
+    private func setLayout() {
+        self.addSubviews(titleLabel, buttonStackView)
+        
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+        
+        buttonStackView.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+        
+        /// Note: 실제 앱에서 적용하는 폰트 적용 후 버튼 높이, 넓이 수정해야함.
+        /// 폰트 크기가 안맞는지 넓이를 피그마 디자인과 동일하게 맞추면 텍스트가 두 줄로 됨. ㅠ
+        
+        latestOrderButton.snp.makeConstraints {
+            $0.width.equalTo(65)
+            $0.height.equalTo(30)
+        }
+        
+        timeOrderButton.snp.makeConstraints {
+            $0.width.equalTo(65)
+            $0.height.equalTo(30)
+        }
+    }
+}

--- a/Projects/Features/QuestionFeature/Sources/Answer/AnswerTableViewCell.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/AnswerTableViewCell.swift
@@ -1,0 +1,93 @@
+//
+//  AnswerTableViewCell.swift
+//  QuestionFeature
+//
+//  Created by playhong on 2/18/24.
+//  Copyright © 2024 Zipthing. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+
+final class AnswerTableViewCell: BaseUITableViewCell<String> {
+    
+    private let userImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.image = UIImage(systemName: "person")
+        iv.tintColor = .gray
+        iv.layer.borderColor = UIColor.black.cgColor
+        iv.layer.borderWidth = 1
+        iv.layer.cornerRadius = 15
+        iv.clipsToBounds = true
+        return iv
+    }()
+    
+    private let userNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
+        label.text = "나는 아빠"
+        return label
+    }()
+    
+    private let writingTimeLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 12, weight: .medium)
+        label.text = "30분 전"
+        label.textColor = .lightGray
+        return label
+    }()
+    
+    private let contentLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 22, weight: .light)
+        label.text = "나는 찍먹이지요~"
+        return label
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 15, bottom: 10, right: 15))
+    }
+    
+    override func setUI() {
+        self.backgroundColor = .clear
+        self.selectionStyle = .none
+        contentView.backgroundColor = .white
+        contentView.layer.borderColor = UIColor.black.cgColor
+        contentView.layer.borderWidth = 1
+        contentView.layer.cornerRadius = 5
+    }
+    
+    override func setLayout() {
+        contentView.addSubviews(userImageView,
+                                userNameLabel,
+                                writingTimeLabel,
+                                contentLabel)
+        
+        userImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(18)
+            $0.leading.equalToSuperview().inset(20)
+            $0.width.height.equalTo(30)
+        }
+        
+        userNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(23)
+            $0.leading.equalTo(userImageView.snp.trailing).offset(10)
+        }
+        
+        writingTimeLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(23)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+        
+        contentLabel.snp.makeConstraints {
+            $0.top.equalTo(userImageView.snp.bottom).offset(19)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+    }
+}
+

--- a/Projects/Features/QuestionFeature/Sources/Answer/AnswerTableViewCell.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/AnswerTableViewCell.swift
@@ -10,12 +10,11 @@ import UIKit
 import DesignSystem
 
 final class AnswerTableViewCell: BaseUITableViewCell<String> {
-    
     private let userImageView: UIImageView = {
         let iv = UIImageView()
         iv.image = UIImage(systemName: "person")
         iv.tintColor = .gray
-        iv.layer.borderColor = UIColor.black.cgColor
+        iv.layer.borderColor = DesignSystemAsset.black.color.cgColor
         iv.layer.borderWidth = 1
         iv.layer.cornerRadius = 15
         iv.clipsToBounds = true
@@ -24,22 +23,22 @@ final class AnswerTableViewCell: BaseUITableViewCell<String> {
     
     private let userNameLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 14, weight: .bold)
+        label.font = ZipthingFont.subTitle4
         label.text = "나는 아빠"
         return label
     }()
     
     private let writingTimeLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 12, weight: .medium)
+        label.font = ZipthingFont.caption4
         label.text = "30분 전"
-        label.textColor = .lightGray
+        label.textColor = DesignSystemAsset.wgray07.color
         return label
     }()
     
     private let contentLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 22, weight: .light)
+        label.font = ZipthingFont.body2
         label.text = "나는 찍먹이지요~"
         return label
     }()
@@ -56,8 +55,8 @@ final class AnswerTableViewCell: BaseUITableViewCell<String> {
     override func setUI() {
         self.backgroundColor = .clear
         self.selectionStyle = .none
-        contentView.backgroundColor = .white
-        contentView.layer.borderColor = UIColor.black.cgColor
+        contentView.backgroundColor = DesignSystemAsset.white.color
+        contentView.layer.borderColor = DesignSystemAsset.black.color.cgColor
         contentView.layer.borderWidth = 1
         contentView.layer.cornerRadius = 5
     }

--- a/Projects/Features/QuestionFeature/Sources/Answer/AnswerViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/AnswerViewController.swift
@@ -18,7 +18,6 @@ protocol AnswerViewControllerDelegate: AnyObject {
 }
 
 public final class AnswerViewController: BaseUIViewController {
-    
     weak var delegate: AnswerViewControllerDelegate?
     private var answerList: [String] = ["1"]
     
@@ -36,7 +35,7 @@ public final class AnswerViewController: BaseUIViewController {
     
     private let grabBarView: UIView = {
         let view = UIView()
-        view.backgroundColor = .black
+        view.backgroundColor = DesignSystemAsset.black.color
         return view
     }()
     
@@ -48,9 +47,9 @@ public final class AnswerViewController: BaseUIViewController {
     
     private let keyboardTextField: UITextField = {
         let tx = UITextField()
-        tx.backgroundColor = .white
+        tx.backgroundColor = DesignSystemAsset.white.color
         tx.placeholder = "답변을 입력해주세요."
-        tx.layer.borderColor = UIColor.black.cgColor
+        tx.layer.borderColor = DesignSystemAsset.black.color.cgColor
         tx.layer.borderWidth = 2
         tx.layer.cornerRadius = 24
         let padding = UIView(frame: CGRect(x: 0, y: 0, width: 23, height: 0))
@@ -79,7 +78,7 @@ public final class AnswerViewController: BaseUIViewController {
     public override func setUI() {
         view.backgroundColor = DesignSystemAsset.wgray03.color
         view.layer.cornerRadius = 12
-        view.layer.borderColor = UIColor.black.cgColor
+        view.layer.borderColor = DesignSystemAsset.black.color.cgColor
         view.layer.borderWidth = 2
         view.isUserInteractionEnabled = true
         createTableHeaderView()

--- a/Projects/Features/QuestionFeature/Sources/Answer/AnswerViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/AnswerViewController.swift
@@ -143,8 +143,10 @@ final class AnswerViewController: BaseUIViewController {
     }
     
     private func createTableHeaderView() {
-        let headerView = AnswerTableHeaderView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 37))
-        tableView.tableHeaderView = headerView
+        if answerList.isEmpty == false {
+            let headerView = AnswerTableHeaderView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 37))
+            tableView.tableHeaderView = headerView
+        }
     }
     
     override func setDelegate() {

--- a/Projects/Features/QuestionFeature/Sources/Answer/AnswerViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/AnswerViewController.swift
@@ -11,7 +11,8 @@ import DesignSystem
 import IQKeyboardManagerSwift
 
 protocol AnswerViewControllerDelegate: AnyObject {
-    func updateParentView()
+    func keyboardWillShow(_ keyboardHeight: CGFloat)
+    func keyboardWillHide()
     func swipeDownGesture()
     func swipeUpGesture()
 }
@@ -215,6 +216,8 @@ final class AnswerViewController: BaseUIViewController {
         guard let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let keyboardHeight = keyboardFrame.cgRectValue.height
         
+        delegate?.keyboardWillShow(keyboardHeight)
+        
         UIView.animate(withDuration: 0.3) { [weak self] in
             guard let self = self else { return }
             
@@ -234,6 +237,8 @@ final class AnswerViewController: BaseUIViewController {
     }
     
     @objc private func keyboardWillHide() {
+        delegate?.keyboardWillHide()
+        
         UIView.animate(withDuration: 0.3) { [weak self] in
             guard let self = self else { return }
             self.bottomView.snp.remakeConstraints {

--- a/Projects/Features/QuestionFeature/Sources/Answer/AnswerViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/AnswerViewController.swift
@@ -17,7 +17,7 @@ protocol AnswerViewControllerDelegate: AnyObject {
     func swipeUpGesture()
 }
 
-final class AnswerViewController: BaseUIViewController {
+public final class AnswerViewController: BaseUIViewController {
     
     weak var delegate: AnswerViewControllerDelegate?
     private var answerList: [String] = ["1"]
@@ -65,18 +65,18 @@ final class AnswerViewController: BaseUIViewController {
         return iv
     }()
     
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         setSwipeGesture()
         setKeyboard()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         IQKeyboardManager.shared.enable = false
     }
     
-    override func setUI() {
+    public override func setUI() {
         view.backgroundColor = DesignSystemAsset.wgray03.color
         view.layer.cornerRadius = 12
         view.layer.borderColor = UIColor.black.cgColor
@@ -93,7 +93,7 @@ final class AnswerViewController: BaseUIViewController {
                          enterImageView)
     }
     
-    override func setLayout() {
+    public override func setLayout() {
         addSubviews()
         createEmptyView()
         grabBarView.snp.makeConstraints {
@@ -149,7 +149,7 @@ final class AnswerViewController: BaseUIViewController {
         }
     }
     
-    override func setDelegate() {
+    public override func setDelegate() {
         tableView.register(AnswerTableViewCell.self, forCellReuseIdentifier: AnswerTableViewCell.identifier)
         tableView.delegate = self
         tableView.dataSource = self
@@ -271,11 +271,11 @@ final class AnswerViewController: BaseUIViewController {
 // MARK: - Extension
 
 extension AnswerViewController: UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return answerList.count
     }
     
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: AnswerTableViewCell.identifier)
                 as? AnswerTableViewCell else { return .init() }
         return cell
@@ -283,18 +283,18 @@ extension AnswerViewController: UITableViewDataSource {
 }
 
 extension AnswerViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let height: CGFloat = 120
         let bottomInset: CGFloat = 10
         return height + bottomInset
     }
     
     /// Note: 테이블 뷰의 헤더뷰와 셀 사이의 Top 간격만 주고 싶어서 비어있는 뷰를 추가해서 높이를 줬음
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 20
     }
     
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return UIView()
     }
 }

--- a/Projects/Features/QuestionFeature/Sources/Answer/AnswerViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/AnswerViewController.swift
@@ -1,0 +1,294 @@
+//
+//  AnswerViewController.swift
+//  QuestionFeature
+//
+//  Created by playhong on 2/18/24.
+//  Copyright © 2024 Zipthing. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+import IQKeyboardManagerSwift
+
+protocol AnswerViewControllerDelegate: AnyObject {
+    func updateParentView()
+    func swipeDownGesture()
+    func swipeUpGesture()
+}
+
+final class AnswerViewController: BaseUIViewController {
+    
+    weak var delegate: AnswerViewControllerDelegate?
+    private var answerList: [String] = ["1"]
+    
+    // MARK: - Components
+    
+    private let emptyView = EmptyAnswerView()
+    
+    private let tableView: UITableView = {
+        let tv = UITableView()
+        tv.backgroundColor = .clear
+        tv.separatorStyle = .none
+        tv.separatorInset = .zero
+        return tv
+    }()
+    
+    private let grabBarView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .black
+        return view
+    }()
+    
+    private let bottomView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        return view
+    }()
+    
+    private let keyboardTextField: UITextField = {
+        let tx = UITextField()
+        tx.backgroundColor = .white
+        tx.placeholder = "답변을 입력해주세요."
+        tx.layer.borderColor = UIColor.black.cgColor
+        tx.layer.borderWidth = 2
+        tx.layer.cornerRadius = 24
+        let padding = UIView(frame: CGRect(x: 0, y: 0, width: 23, height: 0))
+        tx.leftView = padding
+        tx.leftViewMode = .always
+        return tx
+    }()
+    
+    private let enterImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.image = UIImage(named: "enterButton")
+        return iv
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setSwipeGesture()
+        setKeyboard()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        IQKeyboardManager.shared.enable = false
+    }
+    
+    override func setUI() {
+        view.backgroundColor = DesignSystemAsset.wgray03.color
+        view.layer.cornerRadius = 12
+        view.layer.borderColor = UIColor.black.cgColor
+        view.layer.borderWidth = 2
+        view.isUserInteractionEnabled = true
+        createTableHeaderView()
+    }
+    
+    private func addSubviews() {
+        view.addSubviews(grabBarView,
+                         tableView,
+                         bottomView)
+        view.addSubviews(keyboardTextField,
+                         enterImageView)
+    }
+    
+    override func setLayout() {
+        addSubviews()
+        createEmptyView()
+        grabBarView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(20)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(40)
+            $0.height.equalTo(0)
+        }
+        
+        tableView.snp.makeConstraints {
+            $0.top.equalTo(grabBarView.snp.bottom).offset(24)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        bottomView.snp.makeConstraints {
+            $0.top.equalTo(bottomView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(14)
+        }
+        
+        keyboardTextField.snp.makeConstraints {
+            $0.top.equalTo(bottomView.snp.top)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalTo(bottomView.snp.bottom)
+        }
+        
+        enterImageView.snp.makeConstraints {
+            $0.trailing.equalTo(keyboardTextField.snp.trailing).inset(16)
+            $0.centerY.equalTo(bottomView.snp.centerY)
+            $0.width.height.equalTo(0)
+        }
+    }
+    
+    private func createEmptyView() {
+        if answerList.isEmpty {
+            view.addSubview(emptyView)
+            emptyView.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
+        }
+    }
+    
+    private func removeEmptyView() {
+        if answerList.isEmpty == false {
+            emptyView.removeFromSuperview()
+        }
+    }
+    
+    private func createTableHeaderView() {
+        let headerView = AnswerTableHeaderView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 37))
+        tableView.tableHeaderView = headerView
+    }
+    
+    override func setDelegate() {
+        tableView.register(AnswerTableViewCell.self, forCellReuseIdentifier: AnswerTableViewCell.identifier)
+        tableView.delegate = self
+        tableView.dataSource = self
+    }
+    
+    private func setSwipeGesture() {
+        let fullSwipeUp = UISwipeGestureRecognizer(target: self,
+                                                   action: #selector(swipeUpGesture(recognizer:)))
+        fullSwipeUp.direction = .up
+        view.addGestureRecognizer(fullSwipeUp)
+        
+        let swipeDown = UISwipeGestureRecognizer(target: self,
+                                                 action: #selector(swipeDownGesture(recognizer:)))
+        swipeDown.direction = .down
+        view.addGestureRecognizer(swipeDown)
+    }
+    
+    private func setKeyboard() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    func updateGrapBarConstraints(detent: Detent) {
+        switch detent {
+        case .large:
+            grabBarView.snp.updateConstraints {
+                $0.height.equalTo(4)
+            }
+        case .medium:
+            grabBarView.snp.updateConstraints {
+                $0.height.equalTo(4)
+            }
+        case .down:
+            grabBarView.snp.updateConstraints {
+                $0.height.equalTo(0)
+            }
+        }
+    }
+    
+    func updateKeyboardTextField(detent: Detent) {
+        switch detent {
+        case .large:
+            break
+        case .medium:
+            bottomView.snp.updateConstraints {
+                $0.top.equalTo(bottomView.snp.bottom).inset(50)
+            }
+            
+            enterImageView.snp.updateConstraints {
+                $0.width.height.equalTo(34)
+            }
+        case .down:
+            bottomView.snp.updateConstraints {
+                $0.top.equalTo(bottomView.snp.bottom)
+            }
+            
+            enterImageView.snp.updateConstraints {
+                $0.width.height.equalTo(0)
+            }
+        }
+    }
+
+    // MARK: - Action
+    
+    @objc private func keyboardWillShow(_ sender: Notification) {
+        guard let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+        let keyboardHeight = keyboardFrame.cgRectValue.height
+        
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            guard let self = self else { return }
+            
+            self.bottomView.snp.remakeConstraints {
+                $0.top.equalTo(self.bottomView.snp.bottom).inset(50)
+                $0.leading.trailing.equalToSuperview()
+                $0.bottom.equalToSuperview().inset(keyboardHeight)
+            }
+            
+            self.keyboardTextField.snp.updateConstraints {
+                $0.leading.trailing.equalToSuperview()
+            }
+            
+            keyboardTextField.layer.cornerRadius = 0
+            self.view.layoutIfNeeded()
+        }
+    }
+    
+    @objc private func keyboardWillHide() {
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            guard let self = self else { return }
+            self.bottomView.snp.remakeConstraints {
+                $0.top.equalTo(self.bottomView.snp.bottom).inset(50)
+                $0.leading.trailing.equalToSuperview()
+                $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).inset(14)
+            }
+            
+            self.keyboardTextField.snp.updateConstraints {
+                $0.leading.trailing.equalToSuperview().inset(16)
+            }
+            
+            keyboardTextField.layer.cornerRadius = 24
+            self.view.layoutIfNeeded()
+        }
+    }
+    
+    @objc private func swipeUpGesture(recognizer: UISwipeGestureRecognizer) {
+        delegate?.swipeUpGesture()
+    }
+    
+    @objc private func swipeDownGesture(recognizer: UISwipeGestureRecognizer) {
+        keyboardTextField.text = ""
+        delegate?.swipeDownGesture()
+    }
+}
+
+// MARK: - Extension
+
+extension AnswerViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return answerList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: AnswerTableViewCell.identifier)
+                as? AnswerTableViewCell else { return .init() }
+        return cell
+    }
+}
+
+extension AnswerViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        let height: CGFloat = 120
+        let bottomInset: CGFloat = 10
+        return height + bottomInset
+    }
+    
+    /// Note: 테이블 뷰의 헤더뷰와 셀 사이의 Top 간격만 주고 싶어서 비어있는 뷰를 추가해서 높이를 줬음
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 20
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return UIView()
+    }
+}
+

--- a/Projects/Features/QuestionFeature/Sources/Answer/EmptyAnswerView.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/EmptyAnswerView.swift
@@ -1,0 +1,68 @@
+//
+//  EmptyAnswerView.swift
+//  QuestionFeature
+//
+//  Created by playhong on 2/18/24.
+//  Copyright © 2024 Zipthing. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+
+final class EmptyAnswerView: UIView {
+    
+    // MARK: - Components
+    
+    private let emptyImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.image = UIImage(named: "emptyAnswer")
+        return iv
+    }()
+    
+    private let emptyPlaceholderLabel: UILabel = {
+        let label = UILabel()
+        label.text = """
+                        아직 답변이 없어요 ㅠㅠ!
+                        내가 먼저 답변을 남겨보세요!
+                     """
+        label.textColor = .gray
+        label.textAlignment = .center
+        label.font = ZipthingFont.body6
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        self.backgroundColor = .clear
+        self.layer.cornerRadius = 12
+    }
+    
+    private func setLayout() {
+        self.addSubviews(emptyImageView,
+                        emptyPlaceholderLabel)
+        
+        emptyImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(130)
+            $0.centerX.equalToSuperview()
+            $0.width.height.equalTo(100)
+        }
+        
+        emptyPlaceholderLabel.snp.makeConstraints {
+            $0.top.equalTo(emptyImageView.snp.bottom).offset(56)
+            $0.centerX.equalToSuperview()
+        }
+    }
+}
+

--- a/Projects/Features/QuestionFeature/Sources/Answer/EmptyAnswerView.swift
+++ b/Projects/Features/QuestionFeature/Sources/Answer/EmptyAnswerView.swift
@@ -10,7 +10,6 @@ import UIKit
 import DesignSystem
 
 final class EmptyAnswerView: UIView {
-    
     // MARK: - Components
     
     private let emptyImageView: UIImageView = {

--- a/Projects/Features/QuestionFeature/Sources/Detent.swift
+++ b/Projects/Features/QuestionFeature/Sources/Detent.swift
@@ -1,0 +1,15 @@
+//
+//  Detent.swift
+//  QuestionFeature
+//
+//  Created by playhong on 2/18/24.
+//  Copyright © 2024 Zipthing. All rights reserved.
+//
+
+import Foundation
+
+enum Detent {
+    case large
+    case medium
+    case down
+}

--- a/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
@@ -1,0 +1,230 @@
+//
+//  QuestionViewController.swift
+//  QuestionFeature
+//
+//  Created by playhong on 2/18/24.
+//  Copyright © 2024 Zipthing. All rights reserved.
+//
+
+import UIKit
+import DesignSystem
+
+final class QuestionViewController: BaseUIViewController {
+    
+    // MARK: - Components
+    
+    private let childViewController = AnswerViewController()
+    
+    private lazy var stackView: UIStackView = {
+        let sv = UIStackView(arrangedSubviews: [questionBagButton, contentStackView])
+        sv.axis = .vertical
+        sv.alignment = .trailing
+        sv.distribution = .fill
+        sv.spacing = 139
+        return sv
+    }()
+    
+    private let questionBagButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: "timer")
+        configuration.imagePadding = 6
+        configuration.title = "지난 질문"
+        configuration.attributedTitle?.font = ZipthingFont.subTitle4
+        let button = UIButton(configuration: configuration)
+        button.backgroundColor = .black
+        button.tintColor = .white
+        button.layer.cornerRadius = 22
+        return button
+    }()
+    
+    private lazy var contentStackView: UIStackView = {
+        let sv = UIStackView(arrangedSubviews: [titleLabel, questionStackView])
+        sv.axis = .vertical
+        sv.alignment = .leading
+        sv.distribution = .fill
+        sv.spacing = 28
+        return sv
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = ZipthingFont.subTitle3
+        label.text = "오늘의 질문"
+        return label
+    }()
+    
+    private lazy var questionStackView: UIStackView = {
+        let sv = UIStackView(arrangedSubviews: [questionLabel, answerLabel])
+        sv.axis = .vertical
+        sv.distribution = .fill
+        sv.spacing = 5
+        return sv
+    }()
+    
+    private let questionLabel: UILabel = {
+        let label = UILabel()
+        label.font = ZipthingFont.title2
+        label.text = "나의 탕수육 스타일은?"
+        return label
+    }()
+    
+    private let answerLabel: UILabel = {
+        let label = UILabel()
+        label.font = ZipthingFont.title2
+        label.text = "부먹 vs 찍먹"
+        return label
+    }()
+    
+    private lazy var swipeStackView: UIStackView = {
+        let sv = UIStackView(arrangedSubviews: [swipeUpPlaceholderLabel, swipeUpImageView])
+        sv.axis = .vertical
+        sv.alignment = .center
+        sv.distribution = .fill
+        sv.spacing = 7
+        sv.isUserInteractionEnabled = true
+        return sv
+    }()
+    
+    private let swipeUpPlaceholderLabel: UILabel = {
+        let label = UILabel()
+        label.font = ZipthingFont.body6
+        label.text = "열어서 답변 달기"
+        label.textColor = DesignSystemAsset.wgray10.color
+        return label
+    }()
+    
+    private lazy var swipeUpImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.image = UIImage(named: "slide")
+        return iv
+    }()
+    
+    // MARK: - Life Cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setChildViewController()
+        setSwipeGesture()
+    }
+
+    override func setUI() {
+        view.backgroundColor = DesignSystemAsset.yellow05.color
+        
+    }
+    
+    override func setLayout() {
+        addSubviews()
+
+        stackView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).inset(16)
+            $0.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        let questionLabelWidth = view.frame.size.width - 32.0
+        questionLabel.snp.makeConstraints {
+            $0.width.equalTo(questionLabelWidth)
+        }
+        
+        questionBagButton.snp.makeConstraints {
+            $0.width.equalTo(109)
+            $0.height.equalTo(44)
+        }
+
+        swipeStackView.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(43)
+            $0.centerX.equalTo(view.snp.centerX)
+        }
+    }
+    
+    private func addSubviews() {
+        view.addSubviews(stackView,
+                         swipeStackView)
+    }
+    
+    override func setDelegate() {
+        childViewController.delegate = self
+    }
+    
+    private func setSwipeGesture() {
+        let halfSwipeUp = UISwipeGestureRecognizer(target: self,
+                                               action: #selector(handleHalfSwipeUpGesture(recognizer:)))
+        halfSwipeUp.direction = .up
+        swipeStackView.addGestureRecognizer(halfSwipeUp)
+    }
+    
+    private func setChildViewController() {
+        addChild(childViewController)
+        view.addSubview(childViewController.view)
+        view.addConstraints(childViewController.view.constraints)
+        childViewController.didMove(toParent: self)
+        
+        childViewController.view.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(view.snp.bottom)
+            $0.height.equalTo(118)
+        }
+    }
+    
+    // MARK: - Action
+    
+    @objc private func questionBagButtonTapped(_ sender: UIButton) {
+        print("지난 질문 버튼을 눌렀습니다.")
+    }
+    
+    @objc private func handleHalfSwipeUpGesture(recognizer: UISwipeGestureRecognizer) {
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            guard let self = self else { return }
+            self.stackView.snp.updateConstraints {
+                $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).inset(-130)
+            }
+
+            self.childViewController.view.snp.updateConstraints {
+                $0.height.equalTo(594)
+            }
+            
+            self.childViewController.updateGrapBarConstraints(detent: .medium)
+            self.childViewController.updateKeyboardTextField(detent: .medium)
+            self.view.layoutIfNeeded()
+        } completion: { _ in
+            print("일단 중간으로 올릴게!")
+        }
+    }
+}
+
+// MARK: - Extension
+
+extension QuestionViewController: AnswerViewControllerDelegate {
+    func updateParentView() {
+    }
+    
+    func swipeDownGesture() {
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            guard let self = self else { return }
+            self.stackView.snp.updateConstraints {
+                $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).inset(16)
+            }
+            
+            self.childViewController.view.snp.updateConstraints {
+                $0.height.equalTo(118)
+            }
+            
+            self.childViewController.updateGrapBarConstraints(detent: .down)
+            self.childViewController.updateKeyboardTextField(detent: .down)
+            self.view.layoutIfNeeded()
+        } completion: { status in
+            print("일단 내려봐")
+        }
+    }
+    
+    func swipeUpGesture() {
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            self?.childViewController.view.snp.updateConstraints {
+                $0.height.equalTo(793)
+            }
+            
+            self?.view.layoutIfNeeded()
+        } completion: { _ in
+            print("일단 끝까지 올릴게!")
+        }
+    }
+}

--- a/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
@@ -145,10 +145,10 @@ final class QuestionViewController: BaseUIViewController {
     }
     
     private func setSwipeGesture() {
-        let halfSwipeUp = UISwipeGestureRecognizer(target: self,
-                                               action: #selector(handleHalfSwipeUpGesture(recognizer:)))
-        halfSwipeUp.direction = .up
-        swipeStackView.addGestureRecognizer(halfSwipeUp)
+        let swipeUp = UISwipeGestureRecognizer(target: self,
+                                               action: #selector(swipeUpGesture(recognizer:)))
+        swipeUp.direction = .up
+        swipeStackView.addGestureRecognizer(swipeUp)
     }
     
     private func setChildViewController() {
@@ -157,6 +157,7 @@ final class QuestionViewController: BaseUIViewController {
         view.addConstraints(childViewController.view.constraints)
         childViewController.didMove(toParent: self)
         
+        childViewController.view.isUserInteractionEnabled = false
         childViewController.view.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(view.snp.bottom)
@@ -170,7 +171,9 @@ final class QuestionViewController: BaseUIViewController {
         print("지난 질문 버튼을 눌렀습니다.")
     }
     
-    @objc private func handleHalfSwipeUpGesture(recognizer: UISwipeGestureRecognizer) {
+    @objc private func swipeUpGesture(recognizer: UISwipeGestureRecognizer) {
+        childViewController.view.isUserInteractionEnabled = true
+        
         UIView.animate(withDuration: 0.3) { [weak self] in
             guard let self = self else { return }
             self.stackView.snp.updateConstraints {
@@ -222,6 +225,7 @@ extension QuestionViewController: AnswerViewControllerDelegate {
     }
     
     func swipeDownGesture() {
+        childViewController.view.isUserInteractionEnabled = false 
         UIView.animate(withDuration: 0.3) { [weak self] in
             guard let self = self else { return }
             self.stackView.snp.updateConstraints {

--- a/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
@@ -109,7 +109,11 @@ final class QuestionViewController: BaseUIViewController {
 
     override func setUI() {
         view.backgroundColor = DesignSystemAsset.yellow05.color
-        
+    }
+    
+    private func addSubviews() {
+        view.addSubviews(stackView,
+                         swipeStackView)
     }
     
     override func setLayout() {
@@ -135,12 +139,7 @@ final class QuestionViewController: BaseUIViewController {
             $0.centerX.equalTo(view.snp.centerX)
         }
     }
-    
-    private func addSubviews() {
-        view.addSubviews(stackView,
-                         swipeStackView)
-    }
-    
+
     override func setDelegate() {
         childViewController.delegate = self
     }
@@ -185,8 +184,6 @@ final class QuestionViewController: BaseUIViewController {
             self.childViewController.updateGrapBarConstraints(detent: .medium)
             self.childViewController.updateKeyboardTextField(detent: .medium)
             self.view.layoutIfNeeded()
-        } completion: { _ in
-            print("일단 중간으로 올릴게!")
         }
     }
 }
@@ -194,7 +191,34 @@ final class QuestionViewController: BaseUIViewController {
 // MARK: - Extension
 
 extension QuestionViewController: AnswerViewControllerDelegate {
-    func updateParentView() {
+    func keyboardWillShow(_ keyboardHeight: CGFloat) {
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            guard let self = self else { return }
+            self.stackView.snp.updateConstraints {
+                let updateHeight = keyboardHeight + 130
+                $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).inset(-updateHeight)
+            }
+            
+            self.childViewController.view.snp.updateConstraints {
+                let updateHeight = (keyboardHeight / 3) + 594
+                $0.height.equalTo(updateHeight)
+            }
+            self.view.layoutIfNeeded()
+        }
+    }
+    
+    func keyboardWillHide() {
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            guard let self = self else { return }
+            self.stackView.snp.updateConstraints {
+                $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).inset(-130)
+            }
+
+            self.childViewController.view.snp.updateConstraints {
+                $0.height.equalTo(594)
+            }
+            self.view.layoutIfNeeded()
+        }
     }
     
     func swipeDownGesture() {
@@ -211,8 +235,6 @@ extension QuestionViewController: AnswerViewControllerDelegate {
             self.childViewController.updateGrapBarConstraints(detent: .down)
             self.childViewController.updateKeyboardTextField(detent: .down)
             self.view.layoutIfNeeded()
-        } completion: { status in
-            print("일단 내려봐")
         }
     }
     
@@ -223,8 +245,6 @@ extension QuestionViewController: AnswerViewControllerDelegate {
             }
             
             self?.view.layoutIfNeeded()
-        } completion: { _ in
-            print("일단 끝까지 올릴게!")
         }
     }
 }

--- a/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 import DesignSystem
 
 public final class QuestionViewController: BaseUIViewController {
-    
     // MARK: - Components
     
     private let childViewController = AnswerViewController()
@@ -31,7 +30,7 @@ public final class QuestionViewController: BaseUIViewController {
         configuration.title = "지난 질문"
         configuration.attributedTitle?.font = ZipthingFont.subTitle4
         let button = UIButton(configuration: configuration)
-        button.backgroundColor = .black
+        button.backgroundColor = DesignSystemAsset.black.color
         button.tintColor = .white
         button.layer.cornerRadius = 22
         return button
@@ -220,6 +219,7 @@ extension QuestionViewController: AnswerViewControllerDelegate {
             self.childViewController.view.snp.updateConstraints {
                 $0.height.equalTo(594)
             }
+            
             self.view.layoutIfNeeded()
         }
     }

--- a/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import DesignSystem
 
-final class QuestionViewController: BaseUIViewController {
+public final class QuestionViewController: BaseUIViewController {
     
     // MARK: - Components
     
@@ -101,13 +101,13 @@ final class QuestionViewController: BaseUIViewController {
     
     // MARK: - Life Cycle
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         setChildViewController()
         setSwipeGesture()
     }
 
-    override func setUI() {
+    public override func setUI() {
         view.backgroundColor = DesignSystemAsset.yellow05.color
     }
     
@@ -116,7 +116,7 @@ final class QuestionViewController: BaseUIViewController {
                          swipeStackView)
     }
     
-    override func setLayout() {
+    public override func setLayout() {
         addSubviews()
 
         stackView.snp.makeConstraints {
@@ -140,7 +140,7 @@ final class QuestionViewController: BaseUIViewController {
         }
     }
 
-    override func setDelegate() {
+    public override func setDelegate() {
         childViewController.delegate = self
     }
     

--- a/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
+++ b/Projects/Features/QuestionFeature/Sources/Question/QuestionViewController.swift
@@ -225,7 +225,8 @@ extension QuestionViewController: AnswerViewControllerDelegate {
     }
     
     func swipeDownGesture() {
-        childViewController.view.isUserInteractionEnabled = false 
+        childViewController.view.isUserInteractionEnabled = false
+        
         UIView.animate(withDuration: 0.3) { [weak self] in
             guard let self = self else { return }
             self.stackView.snp.updateConstraints {

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray03.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray03.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "204",
-          "green" : "204",
-          "red" : "204"
+          "blue" : "0xCC",
+          "green" : "0xCC",
+          "red" : "0xCC"
         }
       },
       "idiom" : "universal"

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray04.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray04.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "184",
-          "green" : "184",
-          "red" : "184"
+          "blue" : "0xB8",
+          "green" : "0xB8",
+          "red" : "0xB8"
         }
       },
       "idiom" : "universal"

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray05.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray05.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "163",
-          "green" : "163",
-          "red" : "163"
+          "blue" : "0xA3",
+          "green" : "0xA3",
+          "red" : "0xA3"
         }
       },
       "idiom" : "universal"

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray06.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray06.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "143",
-          "green" : "143",
-          "red" : "143"
+          "blue" : "0x8F",
+          "green" : "0x8F",
+          "red" : "0x8F"
         }
       },
       "idiom" : "universal"

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray07.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray07.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "122",
-          "green" : "122",
-          "red" : "122"
+          "blue" : "0x7A",
+          "green" : "0x7A",
+          "red" : "0x7A"
         }
       },
       "idiom" : "universal"

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray08.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray08.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "102",
-          "green" : "102",
-          "red" : "102"
+          "blue" : "0x66",
+          "green" : "0x66",
+          "red" : "0x66"
         }
       },
       "idiom" : "universal"

--- a/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray09.colorset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Gray/gray09.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "82",
-          "green" : "82",
-          "red" : "82"
+          "blue" : "0x52",
+          "green" : "0x52",
+          "red" : "0x52"
         }
       },
       "idiom" : "universal"

--- a/Projects/Shared/DesignSystem/Sources/Utility/ZipthingFont.swift
+++ b/Projects/Shared/DesignSystem/Sources/Utility/ZipthingFont.swift
@@ -8,27 +8,27 @@
 
 import Foundation
 
-enum ZipthingFont {
+public enum ZipthingFont {
     // MARK: - Title
 
-    static let title2 = DesignSystemFontFamily.Pretendard.regular.font(size: 33)
-    static let title4 = DesignSystemFontFamily.Pretendard.regular.font(size: 30)
-    static let title6 = DesignSystemFontFamily.Pretendard.bold.font(size: 20)
-    static let title8 = DesignSystemFontFamily.Pretendard.medium.font(size: 20)
+    public static let title2 = DesignSystemFontFamily.Pretendard.regular.font(size: 33)
+    public static let title4 = DesignSystemFontFamily.Pretendard.regular.font(size: 30)
+    public static let title6 = DesignSystemFontFamily.Pretendard.bold.font(size: 20)
+    public static let title8 = DesignSystemFontFamily.Pretendard.medium.font(size: 20)
     
     // MARK: - Sub Title
 
-    static let subTitle2 = DesignSystemFontFamily.Pretendard.bold.font(size: 19)
-    static let subTitle3 = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
-    static let subTitle4 = DesignSystemFontFamily.Pretendard.bold.font(size: 14)
-    static let subTitle6 = DesignSystemFontFamily.Pretendard.bold.font(size: 12)
+    public static let subTitle2 = DesignSystemFontFamily.Pretendard.bold.font(size: 19)
+    public static let subTitle3 = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
+    public static let subTitle4 = DesignSystemFontFamily.Pretendard.bold.font(size: 14)
+    public static let subTitle6 = DesignSystemFontFamily.Pretendard.bold.font(size: 12)
     
     // MARK: - Body
 
-    static let body2 = DesignSystemFontFamily.Pretendard.light.font(size: 22)
-    static let body4 = DesignSystemFontFamily.Pretendard.regular.font(size: 17)
-    static let body6 = DesignSystemFontFamily.Pretendard.medium.font(size: 16)
-    static let body8 = DesignSystemFontFamily.Pretendard.regular.font(size: 14)
-    static let caption2 = DesignSystemFontFamily.Pretendard.bold.font(size: 12)
-    static let caption4 = DesignSystemFontFamily.Pretendard.medium.font(size: 12)
+    public static let body2 = DesignSystemFontFamily.Pretendard.light.font(size: 22)
+    public static let body4 = DesignSystemFontFamily.Pretendard.regular.font(size: 17)
+    public static let body6 = DesignSystemFontFamily.Pretendard.medium.font(size: 16)
+    public static let body8 = DesignSystemFontFamily.Pretendard.regular.font(size: 14)
+    public static let caption2 = DesignSystemFontFamily.Pretendard.bold.font(size: 12)
+    public static let caption4 = DesignSystemFontFamily.Pretendard.medium.font(size: 12)
 }


### PR DESCRIPTION
## PR Type
- [x] Design
- [ ] Documentation
- [ ] Feature
- [ ] Style
- [ ] Fix
- [ ] Test

## 작업 내용
- 질의 응답 페이지 UI 구현
  
## 작업 사유
- 작업 내용과 동일
  
## 세부 사항
- 질문을 보여주는 화면 QuestionViewController, 답변하는 화면 AnswerViewController
- AnswerViewController의 스와이프 제스쳐 동작 또는 키보드가 올라오거나 내려갈 때, QuestionViewController의 레이아웃 업데이트를 위해 Delegate 패턴을 사용해서 업데이트하도록 구현했습니다.
- 키보드가 올라갈 때, 질문이 사라지도록 구현했습니다. 키보드가 올라가도 질문이 보이는게 좋을까요?
- 필요한 이미지의 경우 ZIP-24 브랜치의  [683fc9fc2c76b2daaf717651574d571a9aea670e] 해당 커밋에서 세령님이 이미지 관련 에셋을 생성했기 때문에 ZIP-24 브랜치 병합 후에 추가하도록 하겠습니다.
  
## 테스트 내용

  
## 스크린샷
|답변 있는 화면|답변 없는 화면|답변 작성 시 키보드 올라오는 화면|
|:-:|:-:|:-:|
|<img src="https://github.com/Haenaet/zipthing-ios/assets/119715960/48355992-2acf-4357-9d8a-a78976ab357d" width="200">|<img src="https://github.com/Haenaet/zipthing-ios/assets/119715960/1e25a8b0-85c0-4749-b6d1-9d790a7af846" width="200">|<img src="https://github.com/Haenaet/zipthing-ios/assets/119715960/e5dfbc07-b394-4451-9517-bd1a8444c3d1" width="200">|

## 참고 자료
